### PR TITLE
NavigationProperty was preserved for unwanted entities 

### DIFF
--- a/EDMXTrimmer/EDMXTrimmer/EdmxTrimmer.cs
+++ b/EDMXTrimmer/EDMXTrimmer/EdmxTrimmer.cs
@@ -87,7 +87,7 @@ namespace EDMXTrimmer
             // Remove all navigation properties
 
             this._xmlDocument.GetElementsByTagName(NAVIGATION_PROPERTY).Cast<XmlNode>()
-                .Where(navProp => !entityTypesFound.Any(entityType => Regex.IsMatch("collection(Microsoft.Dynamics.DataEntities.ReleasedProductsV2)", ENTITYNAMESPACE + entityType + "\\)?$"))).ToList()
+                .Where(navProp => !entityTypesFound.Any(entityType => Regex.IsMatch(navProp.Attributes[ATTRIBUTE_TYPE].Value, ENTITYNAMESPACE + entityType + "\\)?$"))).ToList()
                 .ForEach(n => n.ParentNode.RemoveChild(n));
 
             // Remove entity not required (EntityType)

--- a/EDMXTrimmer/EDMXTrimmer/EdmxTrimmer.cs
+++ b/EDMXTrimmer/EDMXTrimmer/EdmxTrimmer.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Xml;
 using System.Linq;
 using System.Xml.Linq;
+using System.Text.RegularExpressions;
 
 namespace EDMXTrimmer
 {
@@ -85,7 +86,8 @@ namespace EDMXTrimmer
             
             // Remove all navigation properties
 
-            this._xmlDocument.GetElementsByTagName(NAVIGATION_PROPERTY).Cast<XmlNode>().Where(navProp => !entityTypesFound.Any(s => navProp.Attributes[ATTRIBUTE_TYPE].Value.Contains(s))).ToList()
+            this._xmlDocument.GetElementsByTagName(NAVIGATION_PROPERTY).Cast<XmlNode>()
+                .Where(navProp => !entityTypesFound.Any(entityType => Regex.IsMatch("collection(Microsoft.Dynamics.DataEntities.ReleasedProductsV2)", ENTITYNAMESPACE + entityType + "\\)?$"))).ToList()
                 .ForEach(n => n.ParentNode.RemoveChild(n));
 
             // Remove entity not required (EntityType)


### PR DESCRIPTION
#5 introduced a bug. It was not removing NavigationProperty for an entity if name int the list to keep was a sub sting of it. For example, if you want to leave only ReleasedProductVariant it saved NavigationProperty  for ReleasedProductVariantExternalCodes.